### PR TITLE
chore: add GHA workflow to build docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 11.15.x
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: update"

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,21 +72,5 @@ module.exports = {
         trackingId: 'UA-128392643-1'
       }
     },
-    {
-      resolve: 'gatsby-plugin-guess-js',
-      options: {
-        GAViewID: '184230484',
-        jwt: {
-          client_email: process.env.GA_SERVICE_ACCOUNT,
-          private_key: process.env.GA_SERVICE_ACCOUNT_KEY
-        },
-        minimumThreshold: 0.03,
-        // The "period" for fetching analytic data.
-        period: {
-          startDate: new Date(new Date().getTime() - 604800000),
-          endDate: new Date()
-        }
-      }
-    }
   ]
 };


### PR DESCRIPTION
This PR enables docs rebuilding via GitHub Actions. Previously, it was done in [Travis CI](https://github.com/mgechev/revive/blob/b47d9fcb1c54177334fb27caa34577ad123a8958/.travis.yml).

`gatsby-plugin-guess-js` is removed because we don't know `env.GA_SERVICE_ACCOUNT` and `env.GA_SERVICE_ACCOUNT_KEY`. This plugin is not important for now. It is used to enable automatic route-based prefetching in the site, powered by Google Analytics data. This allows Gatsby to prefetch those pages in advance, making navigation feel instant and improving perceived performance.