### PR TITLE
docs: fix wrong link to a rule from the docs page

### DIFF
--- a/infra/download.js
+++ b/infra/download.js
@@ -49,6 +49,8 @@ const handleContent = (markdown, p) => {
     const name = e.attribs.src.split('/').pop();
     markdown = markdown.replace(e.attribs.src, `/images/gen/${name}`);
   });
+  // Replace RULES_DESCRIPTIONS.md links with ./r/ links
+  markdown = markdown.replace(/\]\(\.\/RULES_DESCRIPTIONS\.md#/g, '](./r/#');
   markdown = `---
 path: "${p.path}"
 ---

--- a/infra/download.js
+++ b/infra/download.js
@@ -49,8 +49,8 @@ const handleContent = (markdown, p) => {
     const name = e.attribs.src.split('/').pop();
     markdown = markdown.replace(e.attribs.src, `/images/gen/${name}`);
   });
-  // Replace RULES_DESCRIPTIONS.md links with ./r/ links
-  markdown = markdown.replace(/\]\(\.\/RULES_DESCRIPTIONS\.md#/g, '](./r/#');
+  // Replace RULES_DESCRIPTIONS.md links with ./r links
+  markdown = markdown.replace(/\]\(\.\/RULES_DESCRIPTIONS\.md#/g, '](./r#');
   markdown = `---
 path: "${p.path}"
 ---


### PR DESCRIPTION
Update: This doesn't fix the whole issue.

Fixes #58